### PR TITLE
feat: text record verifier

### DIFF
--- a/script/DeployLinkEmailVerifier.s.sol
+++ b/script/DeployLinkEmailVerifier.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Script, console } from "forge-std/Script.sol";
+import { LinkEmailVerifier } from "../src/LinkEmailVerifier.sol";
+import { LinkEmailCommandVerifier } from "../src/verifiers/LinkEmailCommandVerifier.sol";
+import { Groth16Verifier } from "../test/fixtures/Groth16Verifier.sol";
+
+contract LinkEmailVerifierScript is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+        LinkEmailCommandVerifier commandVerifier = new LinkEmailCommandVerifier(address(new Groth16Verifier()));
+        LinkEmailVerifier verifier = new LinkEmailVerifier(address(commandVerifier));
+        vm.stopBroadcast();
+
+        console.log("LINK_EMAIL_VERIFIER=", address(verifier));
+    }
+}

--- a/script/LinkWithFixture.s.sol
+++ b/script/LinkWithFixture.s.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { LinkEmailVerifier } from "../src/LinkEmailVerifier.sol";
+import { LinkEmailCommand } from "../src/verifiers/LinkEmailCommandVerifier.sol";
+import { TestFixtures } from "../test/fixtures/TestFixtures.sol";
+
+contract LinkWithFixtureScript is Script {
+    address public constant LINK_EMAIL_VERIFIER = 0xe902Bc5bcc1dc15dbDF27FfE346c31c4F8FD37DF; // link email verifier
+        // sepolia
+
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        LinkEmailVerifier verifier = LinkEmailVerifier(LINK_EMAIL_VERIFIER);
+        (LinkEmailCommand memory command,) = TestFixtures.linkEmailCommand();
+
+        vm.startBroadcast(deployerPrivateKey);
+        verifier.entrypoint(abi.encode(command));
+        vm.stopBroadcast();
+    }
+}

--- a/src/LinkEmailVerifier.sol
+++ b/src/LinkEmailVerifier.sol
@@ -15,6 +15,8 @@ import { ITextRecordVerifier } from "./interfaces/ITextRecordVerifier.sol";
 contract LinkEmailVerifier is IEntryPoint, ITextRecordVerifier {
     using EnsUtils for bytes;
 
+    bytes32 private immutable _EMAIL_KEY = keccak256(bytes("email"));
+
     address public immutable VERIFIER; // link email command verifier
 
     mapping(bytes32 node => string emailAddress) public emailAddress; // can only be updated via the entrypoint function
@@ -57,7 +59,7 @@ contract LinkEmailVerifier is IEntryPoint, ITextRecordVerifier {
      */
     function verifyTextRecord(bytes32 node, string memory key, string memory value) external view returns (bool) {
         // this verifier only supports email text record
-        if (keccak256(bytes(key)) != keccak256(bytes("email"))) {
+        if (keccak256(bytes(key)) != _EMAIL_KEY) {
             revert UnsupportedKey();
         }
         string memory storedEmail = emailAddress[node];

--- a/src/LinkEmailVerifier.sol
+++ b/src/LinkEmailVerifier.sol
@@ -15,7 +15,7 @@ import { ITextRecordVerifier } from "./interfaces/ITextRecordVerifier.sol";
 contract LinkEmailVerifier is IEntryPoint, ITextRecordVerifier {
     using EnsUtils for bytes;
 
-    address public immutable VERIFIER;
+    address public immutable VERIFIER; // link email command verifier
 
     mapping(bytes32 node => string emailAddress) public emailAddress; // can only be updated via the entrypoint function
         // with a valid command

--- a/src/ZkEmailRegistrar.sol
+++ b/src/ZkEmailRegistrar.sol
@@ -8,11 +8,11 @@ import { ENS } from "@ensdomains/ens-contracts/contracts/registry/ENS.sol";
 import { Bytes } from "@openzeppelin/contracts/utils/Bytes.sol";
 import { IEntryPoint } from "./interfaces/IEntryPoint.sol";
 import { IResolver } from "./interfaces/IResolver.sol";
+
 /**
  * @title ZkEmailRegistrar
  * @notice A contract for registering email-based ENS names
  */
-
 contract ZkEmailRegistrar is IEntryPoint {
     using Bytes for bytes;
     using EnsUtils for bytes;

--- a/src/interfaces/ITextRecordVerifier.sol
+++ b/src/interfaces/ITextRecordVerifier.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+interface ITextRecordVerifier {
+    error UnsupportedKey();
+
+    /**
+     * @notice Verifies the text record for the given node, key and value
+     * @param node The node to verify the text record for (namehash of the ENS name)
+     * @param key The key of the text record (e.g. "email")
+     * @param value The value of the text record (e.g. "test@example.com")
+     * @return isValid True if the text record is valid, false otherwise
+     */
+    function verifyTextRecord(bytes32 node, string memory key, string memory value) external view returns (bool);
+}

--- a/test/src/LinkEmail/LinkEmailVerifier.t.sol
+++ b/test/src/LinkEmail/LinkEmailVerifier.t.sol
@@ -38,6 +38,20 @@ contract LinkEmailVerifierTest is Test {
         linkEmail.entrypoint(encodedCommand);
     }
 
+    function test_verifyTextRecord_returnsTrueWhenTextRecordIsCorrect() public {
+        (LinkEmailCommand memory command, uint256[60] memory pubSignals) = TestFixtures.linkEmailCommand();
+        bytes memory encodedCommand = linkEmail.encode(_toDynamicArray(pubSignals), command.proof.proof);
+        linkEmail.entrypoint(encodedCommand);
+        assertEq(linkEmail.verifyTextRecord(bytes(command.ensName).namehash(), "email", command.email), true);
+    }
+
+    function test_verifyTextRecord_returnsFalseWhenTextRecordIsIncorrect() public {
+        (LinkEmailCommand memory command, uint256[60] memory pubSignals) = TestFixtures.linkEmailCommand();
+        bytes memory encodedCommand = linkEmail.encode(_toDynamicArray(pubSignals), command.proof.proof);
+        linkEmail.entrypoint(encodedCommand);
+        assertEq(linkEmail.verifyTextRecord(bytes(command.ensName).namehash(), "email", "incorrect@e.com"), false);
+    }
+
     function _toDynamicArray(uint256[60] memory pubSignals) internal pure returns (uint256[] memory) {
         uint256[] memory pubSignalsArray = new uint256[](60);
         for (uint256 i = 0; i < 60; i++) {


### PR DESCRIPTION
## Changes

### New Files
- **`script/DeployLinkEmailVerifier.s.sol`** - Deployment script for LinkEmailVerifier contract
- **`script/LinkWithFixture.s.sol`** - Script to execute link email using test fixtures  
- **`src/interfaces/ITextRecordVerifier.sol`** - Interface defining text record verification functionality

### Modified Files
- **`src/LinkEmailVerifier.sol`**
  - Implements `ITextRecordVerifier` interface
  - Adds `verifyTextRecord()` function to validate email text records for ENS nodes
  - Supports verification of "email" key against stored email addresses
  - Includes `UnsupportedKey()` error for unsupported record types

- **`test/src/LinkEmail/LinkEmailVerifier.t.sol`**
  - Adds `test_verifyTextRecord_returnsTrueWhenTextRecordIsCorrect()` test case
  - Adds `test_verifyTextRecord_returnsFalseWhenTextRecordIsIncorrect()` test case

### Functionality Added
- Text record verification capability for ENS email records
- Deployment and testing infrastructure for LinkEmailVerifier contract
- Support for validating email text records against stored mappings